### PR TITLE
Set max_instances in app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,8 @@
 runtime: nodejs20
 
+automatic_scaling:
+  max_instances: 1
+
 handlers:
 - url: /wp-.*
   static_files: dist/error_page.html


### PR DESCRIPTION
Updated app.yaml to include automatic_scaling.max_instances: 1 to comply with App Engine's upcoming default scaling policy changes and resolve deployment warnings.

---
*PR created automatically by Jules for task [47132261668458781](https://jules.google.com/task/47132261668458781) started by @ronshapiro*