### PR TITLE
Update "Days to Go" calculation in Daf Yomi Lag Calculator

### DIFF
--- a/static/dapim_left.html
+++ b/static/dapim_left.html
@@ -44,6 +44,7 @@
 
         const STORAGE_KEY = 'daf_yomi_calculator_react_v1';
         const CACHE_KEY = 'daf_yomi_target_cache_v1';
+        const TOTAL_DAYS = 2711;
 
         // Icon Components (Inline SVG for Zero Dependencies)
         const IconCalculator = () => <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="16" height="20" x="4" y="2" rx="2"/><line x1="8" x2="16" y1="6" y2="6"/><line x1="16" x2="16" y1="14" y2="18"/><path d="M16 10h.01"/><path d="M12 10h.01"/><path d="M8 10h.01"/><path d="M12 14h.01"/><path d="M8 14h.01"/><path d="M12 18h.01"/><path d="M8 18h.01"/></svg>;
@@ -235,7 +236,7 @@
                                 <div className="text-center px-2 border-l border-slate-100/50">
                                     <div className="text-[10px] uppercase font-bold text-slate-400 mb-1">Days to Go</div>
                                     <div className={`text-lg font-bold ${hasData && lag <= 0 ? 'text-white' : 'text-slate-700'}`}>
-                                        {2711 - userTotal} <span className="text-[10px] font-normal opacity-50">days</span>
+                                        {TOTAL_DAYS - targetTotal} <span className="text-[10px] font-normal opacity-50">days</span>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
The user requested to change the "Days to Go" calculation in the Daf Yomi Lag Calculator.
Previously, it was showing the number of pages the user had left to learn (2711 - userTotal).
The new requirement is to show how many days are left until the current cycle is finished (2711 - targetTotal).

I have modified `static/dapim_left.html` to update this calculation and verified it with a Playwright script. I also ensured that the change doesn't break any existing tests.

---
*PR created automatically by Jules for task [14056246048386817541](https://jules.google.com/task/14056246048386817541) started by @ronshapiro*