### PR TITLE
Add Gray Mode intermediate theme

### DIFF
--- a/css/grayMode.css
+++ b/css/grayMode.css
@@ -1,0 +1,33 @@
+:root {
+    --background-color: #707070;
+    --text-color: #f0f0f0;
+    --english-text-color: #e0e0e0;
+    --rashi-quotation-text-color: #ffd0d0;
+    --snackbar-button-color: var(--text-color);
+    --snackbar-disabled-button-color: rgb(160, 160, 160);
+    --snackbar-background-color: #444;
+    --snackbar-text-color: var(--text-color);
+    --highlight-red: rgb(200, 120, 115);
+    --highlight-red-50: rgb(200, 120, 115, .5);
+    --highlight-yellow: rgb(180, 175, 100);
+    --highlight-yellow-50: rgb(180, 175, 100, .5);
+    --highlight-green: rgb(110, 180, 120);
+    --highlight-green-50: rgb(110, 180, 120, .5);
+    --highlight-blue: rgb(110, 160, 180);
+    --highlight-blue-50: rgb(110, 160, 180, .5);
+    --highlight-gray: rgb(150, 150, 150);
+    --highlight-gray-50: rgb(150, 150, 150, .5);
+    --highlighted-commentary-indicator-yellow: rgb(190, 185, 110);
+    --modal-box-shadow-color: #444;
+    --modal-button-color: var(--mdl-accent-color);
+
+    --selection-background-color: #ffffff44;
+}
+
+::selection {
+    background: var(--selection-background-color);
+}
+
+::-moz-selection {
+    background: var(--selection-background-color);
+}

--- a/js/Feedback.tsx
+++ b/js/Feedback.tsx
@@ -67,6 +67,8 @@ export function FeedbackView({hide}: FeedbackViewProps): React.ReactElement {
   useEffect(() => {
     const darkMode = document.getElementById("darkModeCss") as HTMLStyleElement;
     if (darkMode) darkMode.disabled = true;
+    const grayMode = document.getElementById("grayModeCss") as HTMLStyleElement;
+    if (grayMode) grayMode.disabled = true;
   });
   const rootRef = useHtmlRef<HTMLDivElement>();
   const collectData = (stage?: string) => {

--- a/js/Preferences.tsx
+++ b/js/Preferences.tsx
@@ -176,6 +176,7 @@ function preferenceOptions(
       titleHebrew="תצוגה"
       items={[
         {value: "true", displayText: "Dark Mode", displayTextHebrew: "כהה"},
+        {value: "gray", displayText: "Gray Mode", displayTextHebrew: "אפור"},
         {value: "false", displayText: "Light Mode", displayTextHebrew: "בהיר"},
       ]}
       rerender={rerender}

--- a/js/SnackbarReact.tsx
+++ b/js/SnackbarReact.tsx
@@ -29,7 +29,8 @@ function SnackbarButton({children, disabled, onClick, extraClasses}: SnackbarBut
   const buttonClasses = [
     "mdl-button",
     "mdl-js-button",
-    (localStorage.darkMode !== "true") ? "mdl-button--colored" : "mdl-button--normal-text-color",
+    (localStorage.darkMode !== "true" && localStorage.darkMode !== "gray")
+      ? "mdl-button--colored" : "mdl-button--normal-text-color",
   ].concat(extraClasses || []).join(" ");
   return (
     <button className={buttonClasses} disabled={disabled} onClick={onClick}>

--- a/js/hooks.ts
+++ b/js/hooks.ts
@@ -18,6 +18,8 @@ export function useUpdateDarkMode(): void {
   useEffect(() => {
     (document.getElementById("darkModeCss") as HTMLLinkElement).disabled = (
       localStorage.darkMode !== "true");
+    (document.getElementById("grayModeCss") as HTMLLinkElement).disabled = (
+      localStorage.darkMode !== "gray");
     for (const id of ["theme-color", "theme-color-dark-mode"]) {
       (document.getElementById(id) as HTMLMetaElement).content = (
         getComputedStyle(document.body).getPropertyValue('--background-color'));

--- a/js/snackbar.ts
+++ b/js/snackbar.ts
@@ -45,7 +45,8 @@ function updateSnackbar(kind: Kind, labelHtml: string, maybeButtons: MaybeButton
   const buttonClasses = [
     "mdl-button",
     "mdl-js-button",
-    (localStorage.darkMode !== "true") ? "mdl-button--colored" : "mdl-button--normal-text-color",
+    (localStorage.darkMode !== "true" && localStorage.darkMode !== "gray")
+      ? "mdl-button--colored" : "mdl-button--normal-text-color",
   ].join(" ");
   $container.find(".snackbar-buttons").html(
     buttons

--- a/templates/header_common.html
+++ b/templates/header_common.html
@@ -34,12 +34,14 @@
 
 <link rel="stylesheet" href="/css/{{random_hash}}/main.css" />
 <link rel="stylesheet" href="/css/{{random_hash}}/darkMode.css" id="darkModeCss"/>
+<link rel="stylesheet" href="/css/{{random_hash}}/grayMode.css" id="grayModeCss"/>
 {% if debug %}
 <link rel="stylesheet" href="/css/{{random_hash}}/debug.css" />
 {% endif %}
 
 <script>
   document.getElementById("darkModeCss").disabled = localStorage.darkMode !== "true";
+  document.getElementById("grayModeCss").disabled = localStorage.darkMode !== "gray";
 </script>
 
 <link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png">


### PR DESCRIPTION
This PR adds a new "Gray Mode" theme to the application, providing an intermediate reading experience between the existing Light and Dark modes.

Key changes:
- **Intermediate Styles:** Added `css/grayMode.css` defining variables for background, text, and highlights that offer better readability than Dark Mode while remaining easier on the eyes than Light Mode.
- **UI Integration:** Added a "Gray Mode" option to the Display section in the Preferences menu.
- **Theme Management:** Updated the application's theme-switching logic (in React hooks and HTML templates) to support three distinct modes ("false", "true", and "gray").
- **Component Consistency:** Updated Snackbars and the Feedback view to ensure appropriate styling and behavior when Gray Mode is active.

All 181 core tests passed, and the implementation follows existing patterns for theme management in the codebase.

---
*PR created automatically by Jules for task [9227906091188268963](https://jules.google.com/task/9227906091188268963) started by @ronshapiro*